### PR TITLE
Fix UB which led to an infinite loop due to using `nconc` on the result of a backquote

### DIFF
--- a/docstrings.lisp
+++ b/docstrings.lisp
@@ -613,7 +613,7 @@ an item in an itemization."
                (when sub-lines-consumed
                  (incf line-number (1- sub-lines-consumed)) ; +1 on next loop
                  (incf lines-consumed sub-lines-consumed)
-                 (setf result (nconc (nreverse sub-itemization) result)))))
+                 (setf result (append (nreverse sub-itemization) result)))))
             ((and offset (= indentation this-offset))
              ;; start of new item
              (push (format nil "@item ~A"


### PR DESCRIPTION
Prior to this commit, recursive calls to `collect-maybe-itemized-section` due to nested lists would call `nconc` to concatenate the result of the recursive call. That result was produced by a backquote template whose final item was not a splicing-unquote. As a result, the `nconc` would mutate the template, so future calls to `collect-maybe-itemized-section` would either loop infinitely or return a circular list.